### PR TITLE
Update nan

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "url": "git://github.com/akimasa/vscode-sqlite3.git"
   },
   "dependencies": {
-    "nan": "^2.14.0"
+    "nan": "^2.15.0"
   },
   "devDependencies": {
     "@mapbox/cloudfriend": "^1.9.0",


### PR DESCRIPTION
Brings in https://github.com/nodejs/nan/pull/888 - without it this fails to build on Ubuntu 20.04